### PR TITLE
fix: added multiple mount points

### DIFF
--- a/charts/cf-explorer-infra/templates/kafka-statefulset.yaml
+++ b/charts/cf-explorer-infra/templates/kafka-statefulset.yaml
@@ -76,6 +76,10 @@ spec:
           volumeMounts:
             - mountPath: /var/lib/kafka/data
               name: kafka-explorer
+              subPath: data
+            - mountPath: /etc/kafka/secrets
+              name: kafka-explorer
+              subPath: secrets
       volumes:
         - name: kafka-init
           configMap:

--- a/charts/cf-explorer-infra/templates/zookeeper-statefulset.yaml
+++ b/charts/cf-explorer-infra/templates/zookeeper-statefulset.yaml
@@ -38,6 +38,24 @@ spec:
               command: [ '/bin/bash', '-c', 'echo "ruok" | nc -w 2 localhost 2181 | grep imok' ]
             failureThreshold: 12
             periodSeconds: 5
+          volumeMounts:
+            - mountPath: /var/lib/kafka/data
+              name: zookeeper-db
+              subPath: data
+            - mountPath: /var/lib/kafka/log
+              name: zookeeper-db
+              subPath: log
+            - mountPath: /etc/zookeeper/secrets
+              name: zookeeper-db
+              subPath: secrets
+  volumeClaimTemplates:
+    - metadata:
+        name: "zookeeper-db"
+      spec:
+        accessModes: [ "ReadWriteOnce" ]
+        resources:
+          requests:
+            storage: {{ .dbSize | default "1Gi" }}
   revisionHistoryLimit: 2
 {{ end }}
 {{ end }}


### PR DESCRIPTION
# Kafka a Zookeeper screwed up volumes

After a crash, zookeeper and kafka lose their log and secrets folders as they're persisted.

This PR aims to ensure such folders are persisted over crashes